### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/backendFlow.yaml
+++ b/.github/workflows/backendFlow.yaml
@@ -86,7 +86,7 @@ jobs:
         run:  mkdir -p app/${{ matrix.module }}/build/dependency && (cd app/${{ matrix.module }}/build/dependency; jar -xf ../libs/*.jar)
 
       - name: Publish to DockerHub module ${{ matrix.module }}
-        uses: elgohr/Publish-Docker-Github-Action@master
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: mateusz43211/tourdeshot
           username: ${{ secrets.DOCKER_USERNAME }}

--- a/.github/workflows/frontendFlow.yaml
+++ b/.github/workflows/frontendFlow.yaml
@@ -59,7 +59,7 @@ jobs:
           path: ui/dist/ui
 
       - name: Publish to DockerHub
-        uses: elgohr/Publish-Docker-Github-Action@master
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: mateusz43211/tourdeshot
           username: ${{ secrets.DOCKER_USERNAME }}


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore